### PR TITLE
Add type safety to endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.dylib
 /cmaj
 .env
+cmake-build-*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ static = ["dep:cmake"]
 bytes = "1.5.0"
 dotenvy = "0.15.7"
 libloading = "0.8.0"
+real-time = { git = "https://github.com/JamesHallowell/real-time", branch = "master" }
+sealed = "0.5"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
-smallvec = "1.11.1"
+smallvec = { version = "1.11.1", features = ["serde"] }
 thiserror = "1.0.48"
 
 [dev-dependencies]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6,7 +6,7 @@ mod program_details;
 pub use annotation::Annotation;
 use {
     crate::{
-        endpoint::{EndpointHandle, Endpoints},
+        endpoint::{EndpointHandle, ProgramEndpoints},
         engine::program_details::ProgramDetails,
         ffi::EnginePtr,
         performer::Performer,
@@ -131,7 +131,7 @@ pub struct Loaded;
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct Linked {
-    endpoints: Arc<Endpoints>,
+    endpoints: Arc<ProgramEndpoints>,
 }
 
 impl Engine<Idle> {
@@ -188,7 +188,7 @@ impl Engine<Loaded> {
                 .map(|handle| (handle, endpoint))
         });
 
-        let endpoints = Endpoints::new(endpoints);
+        let endpoints = ProgramEndpoints::new(endpoints);
 
         match self.inner.link() {
             Ok(_) => {

--- a/src/ffi/performer.rs
+++ b/src/ffi/performer.rs
@@ -86,7 +86,7 @@ impl PerformerPtr {
             ((*(*self.performer).vtable).add_input_event)(
                 self.performer,
                 handle.into(),
-                type_index.into(),
+                usize::from(type_index) as u32,
                 data_ptr,
             )
         };
@@ -158,7 +158,7 @@ impl PerformerPtr {
                 (*callback)(
                     frame_offset as usize,
                     endpoint.into(),
-                    type_index.into(),
+                    (type_index as usize).into(),
                     data,
                 );
             });

--- a/src/performer/atomic.rs
+++ b/src/performer/atomic.rs
@@ -1,0 +1,27 @@
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+#[derive(Default)]
+pub struct AtomicF32(AtomicU32);
+
+impl AtomicF32 {
+    pub fn load(&self, order: Ordering) -> f32 {
+        f32::from_bits(self.0.load(order))
+    }
+
+    pub fn store(&self, value: f32, order: Ordering) {
+        self.0.store(value.to_bits(), order);
+    }
+}
+
+#[derive(Default)]
+pub struct AtomicF64(AtomicU64);
+
+impl AtomicF64 {
+    pub fn load(&self, order: Ordering) -> f64 {
+        f64::from_bits(self.0.load(order))
+    }
+
+    pub fn store(&self, value: f64, order: Ordering) {
+        self.0.store(value.to_bits(), order);
+    }
+}

--- a/src/performer/endpoints/input_event.rs
+++ b/src/performer/endpoints/input_event.rs
@@ -1,0 +1,82 @@
+use {
+    crate::{
+        endpoint::{EndpointDirection, EndpointTypeIndex},
+        performer::{
+            Endpoint, EndpointError, Performer, PerformerEndpoint, __seal_performer_endpoint,
+        },
+        value::{types::Type, Value},
+    },
+    real_time::fifo,
+    sealed::sealed,
+    std::marker::PhantomData,
+};
+
+/// An endpoint for input events.
+pub struct InputEvent<T = Value> {
+    types: Vec<Type>,
+    tx: fifo::Producer<(EndpointTypeIndex, Value)>,
+    _marker: PhantomData<T>,
+}
+
+impl Endpoint<InputEvent<Value>> {
+    /// Post an event to the endpoint.
+    pub fn post(&self, value: impl Into<Value>) -> Result<(), EndpointError> {
+        let value = value.into();
+
+        let index = self
+            .inner
+            .types
+            .iter()
+            .position(|t| t.as_ref() == value.ty())
+            .map(EndpointTypeIndex::from)
+            .ok_or(EndpointError::DataTypeMismatch)?;
+
+        self.inner
+            .tx
+            .push((index, value))
+            .map_err(|_e| EndpointError::FailedToSendMessageToPerformer)?;
+
+        Ok(())
+    }
+}
+
+#[sealed]
+impl PerformerEndpoint for InputEvent<Value> {
+    fn make(id: &str, performer: &mut Performer) -> Result<Endpoint<Self>, EndpointError> {
+        let (handle, endpoint) = performer
+            .endpoints
+            .get_by_id(id)
+            .ok_or(EndpointError::EndpointDoesNotExist)?;
+
+        if endpoint.direction() != EndpointDirection::Input {
+            return Err(EndpointError::DirectionMismatch);
+        }
+
+        let endpoint = endpoint
+            .as_event()
+            .ok_or(EndpointError::EndpointTypeMismatch)?;
+
+        let (tx, rx) = fifo::fifo(4);
+
+        let input_event = InputEvent {
+            types: endpoint.types().to_vec(),
+            tx,
+            _marker: PhantomData,
+        };
+
+        performer.inputs.push(Box::new(move |performer| {
+            let mut n_to_pop_before_yielding = 4;
+            while let Some(value) = rx.pop_ref() {
+                if n_to_pop_before_yielding == 0 {
+                    break;
+                }
+                n_to_pop_before_yielding -= 1;
+
+                let (index, value) = &*value;
+                value.with_bytes(|bytes| performer.add_input_event(handle, *index, bytes));
+            }
+        }));
+
+        Ok(Endpoint { inner: input_event })
+    }
+}

--- a/src/performer/endpoints/input_value.rs
+++ b/src/performer/endpoints/input_value.rs
@@ -1,0 +1,198 @@
+use {
+    crate::{
+        endpoint::{EndpointDirection, EndpointHandle},
+        ffi::PerformerPtr,
+        performer::{
+            atomic::{AtomicF32, AtomicF64},
+            endpoints::Endpoint,
+            EndpointError, EndpointHandler, Performer, PerformerEndpoint,
+            __seal_performer_endpoint,
+        },
+        value::{
+            types::{Primitive, Type},
+            Value,
+        },
+    },
+    real_time::reader::realtime_reader,
+    sealed::sealed,
+    std::{
+        any::TypeId,
+        collections::HashMap,
+        marker::PhantomData,
+        sync::{
+            atomic::{AtomicI32, AtomicI64, Ordering},
+            Arc, Mutex,
+        },
+    },
+};
+
+/// An endpoint for input values.
+pub struct InputValue<T = Value> {
+    ty: Type,
+    writer: Writer,
+    _marker: PhantomData<fn(T)>,
+}
+
+type Writer = Arc<dyn Fn(Value) + Sync + Send>;
+
+#[derive(Default)]
+pub struct CachedInputValues {
+    writers: HashMap<EndpointHandle, Writer>,
+}
+
+impl Endpoint<InputValue<bool>> {
+    /// Set the value of the endpoint.
+    pub fn set(&self, value: bool) {
+        (self.inner.writer)(Value::Int32(if value { 1 } else { 0 }));
+    }
+}
+
+impl Endpoint<InputValue<i32>> {
+    /// Set the value of the endpoint.
+    pub fn set(&self, value: i32) {
+        (self.inner.writer)(value.into());
+    }
+}
+
+impl Endpoint<InputValue<i64>> {
+    /// Set the value of the endpoint.
+    pub fn set(&self, value: i64) {
+        (self.inner.writer)(value.into());
+    }
+}
+
+impl Endpoint<InputValue<f32>> {
+    /// Set the value of the endpoint.
+    pub fn set(&self, value: f32) {
+        (self.inner.writer)(value.into());
+    }
+}
+
+impl Endpoint<InputValue<f64>> {
+    /// Set the value of the endpoint.
+    pub fn set(&self, value: f64) {
+        (self.inner.writer)(value.into());
+    }
+}
+
+impl Endpoint<InputValue<Value>> {
+    /// Set the value of the endpoint. The type is checked at runtime.
+    pub fn set(&self, value: impl Into<Value>) -> Result<(), EndpointError> {
+        let value = value.into();
+        if self.inner.ty.as_ref() != value.ty() {
+            return Err(EndpointError::DataTypeMismatch);
+        }
+        (self.inner.writer)(value);
+        Ok(())
+    }
+}
+
+#[sealed]
+impl<T> PerformerEndpoint for InputValue<T>
+where
+    T: 'static,
+{
+    fn make(id: &str, performer: &mut Performer) -> Result<Endpoint<Self>, EndpointError> {
+        let (handle, endpoint) = performer
+            .endpoints
+            .get_by_id(id)
+            .ok_or(EndpointError::EndpointDoesNotExist)?;
+
+        if endpoint.direction() != EndpointDirection::Input {
+            return Err(EndpointError::DirectionMismatch);
+        }
+
+        let endpoint = endpoint
+            .as_value()
+            .ok_or(EndpointError::EndpointTypeMismatch)?;
+
+        let user_type = TypeId::of::<T>();
+        if user_type != TypeId::of::<Value>() {
+            if let Some(endpoint_type) = endpoint.ty().type_id() {
+                if user_type != endpoint_type {
+                    return Err(EndpointError::DataTypeMismatch);
+                }
+            } else {
+                return Err(EndpointError::DataTypeMismatch);
+            }
+        }
+
+        let writer = match performer.cached_input_values.writers.get(&handle) {
+            Some(writer) => Arc::clone(writer),
+            None => {
+                let (writer, handler) = make_endpoint_connection(handle, endpoint.ty());
+                performer
+                    .cached_input_values
+                    .writers
+                    .insert(handle, Arc::clone(&writer));
+                performer.inputs.push(handler);
+                writer
+            }
+        };
+
+        Ok(Endpoint {
+            inner: InputValue {
+                ty: endpoint.ty().clone(),
+                writer,
+                _marker: PhantomData,
+            },
+        })
+    }
+}
+
+macro_rules! primitive_impl {
+    ($handle:ident, $ty:ty, $atomic:ty) => {
+        let reader = Arc::new(<$atomic>::default());
+        let writer = Arc::clone(&reader);
+
+        return (
+            Arc::new(move |value| {
+                if let Ok(value) = TryInto::<$ty>::try_into(value.as_ref()) {
+                    writer.store(value, Ordering::Relaxed);
+                }
+            }),
+            Box::new(move |performer: &mut PerformerPtr| {
+                let value = reader.load(Ordering::Relaxed);
+                unsafe { performer.set_input_value($handle, value.to_ne_bytes().as_ptr(), 0) };
+            }),
+        );
+    };
+}
+
+fn make_endpoint_connection(handle: EndpointHandle, ty: &Type) -> (Writer, EndpointHandler) {
+    match ty {
+        Type::Primitive(Primitive::Bool) => {
+            primitive_impl!(handle, i32, AtomicI32);
+        }
+        Type::Primitive(Primitive::Int32) => {
+            primitive_impl!(handle, i32, AtomicI32);
+        }
+        Type::Primitive(Primitive::Int64) => {
+            primitive_impl!(handle, i64, AtomicI64);
+        }
+        Type::Primitive(Primitive::Float32) => {
+            primitive_impl!(handle, f32, AtomicF32);
+        }
+        Type::Primitive(Primitive::Float64) => {
+            primitive_impl!(handle, f64, AtomicF64);
+        }
+        _ => {
+            let (writer, mut reader) = realtime_reader(None);
+            let writer = Mutex::new(writer);
+
+            return (
+                Arc::new(move |value| {
+                    writer.lock().unwrap().set(Some(value));
+                }),
+                Box::new(move |performer| {
+                    let reader = reader.lock();
+                    if let Some(value) = reader.as_ref() {
+                        value.with_bytes(|bytes| {
+                            unsafe { performer.set_input_value(handle, bytes.as_ptr(), 0) };
+                        });
+                    }
+                }),
+            );
+        }
+    }
+}

--- a/src/performer/endpoints/mod.rs
+++ b/src/performer/endpoints/mod.rs
@@ -1,0 +1,11 @@
+mod input_event;
+mod input_value;
+mod output_value;
+
+/// An endpoint.
+pub struct Endpoint<T> {
+    inner: T,
+}
+
+pub(crate) use input_value::CachedInputValues;
+pub use {input_event::InputEvent, input_value::InputValue, output_value::OutputValue};

--- a/src/performer/endpoints/output_value.rs
+++ b/src/performer/endpoints/output_value.rs
@@ -1,0 +1,180 @@
+use {
+    crate::{
+        endpoint::{EndpointDirection, EndpointHandle},
+        ffi::PerformerPtr,
+        performer::{
+            atomic::{AtomicF32, AtomicF64},
+            endpoints::Endpoint,
+            EndpointError, EndpointHandler, Performer, PerformerEndpoint,
+            __seal_performer_endpoint,
+        },
+        value::{
+            types::{Primitive, Type},
+            Value, ValueRef,
+        },
+    },
+    real_time::writer::realtime_writer,
+    sealed::sealed,
+    std::{
+        any::TypeId,
+        marker::PhantomData,
+        sync::{
+            atomic::{AtomicI32, AtomicI64, Ordering},
+            Arc,
+        },
+    },
+};
+
+/// An endpoint for output values.
+pub struct OutputValue<T = Value> {
+    reader: Reader,
+    _marker: PhantomData<fn() -> T>,
+}
+
+type Reader = Box<dyn FnMut() -> Value + Send>;
+
+impl Endpoint<OutputValue<bool>> {
+    /// Read the value of the endpoint.
+    pub fn get(&mut self) -> bool {
+        let value: Result<i32, ()> = (self.inner.reader)().as_ref().try_into();
+        debug_assert!(value.is_ok());
+        value.unwrap_or_default() != 0
+    }
+}
+
+impl Endpoint<OutputValue<i32>> {
+    /// Read the value of the endpoint.
+    pub fn get(&mut self) -> i32 {
+        let value = (self.inner.reader)().as_ref().try_into();
+        debug_assert!(value.is_ok());
+        value.unwrap_or_default()
+    }
+}
+
+impl Endpoint<OutputValue<i64>> {
+    /// Read the value of the endpoint.
+    pub fn get(&mut self) -> i64 {
+        let value = (self.inner.reader)().as_ref().try_into();
+        debug_assert!(value.is_ok());
+        value.unwrap_or_default()
+    }
+}
+
+impl Endpoint<OutputValue<f32>> {
+    /// Read the value of the endpoint.
+    pub fn get(&mut self) -> f32 {
+        let value = (self.inner.reader)().as_ref().try_into();
+        debug_assert!(value.is_ok());
+        value.unwrap_or_default()
+    }
+}
+
+impl Endpoint<OutputValue<f64>> {
+    /// Read the value of the endpoint.
+    pub fn get(&mut self) -> f64 {
+        let value = (self.inner.reader)().as_ref().try_into();
+        debug_assert!(value.is_ok());
+        value.unwrap_or_default()
+    }
+}
+
+impl Endpoint<OutputValue<Value>> {
+    /// Read the value of the endpoint.
+    pub fn get(&mut self) -> Value {
+        (self.inner.reader)()
+    }
+}
+
+#[sealed]
+impl<T> PerformerEndpoint for OutputValue<T>
+where
+    T: 'static,
+{
+    fn make(id: &str, performer: &mut Performer) -> Result<Endpoint<Self>, EndpointError> {
+        let (handle, endpoint) = performer
+            .endpoints
+            .get_by_id(id)
+            .ok_or(EndpointError::EndpointDoesNotExist)?;
+
+        if endpoint.direction() != EndpointDirection::Output {
+            return Err(EndpointError::DirectionMismatch);
+        }
+
+        let endpoint = endpoint
+            .as_value()
+            .ok_or(EndpointError::EndpointTypeMismatch)?;
+
+        let user_type = TypeId::of::<T>();
+        if user_type != TypeId::of::<Value>() {
+            if let Some(endpoint_type) = endpoint.ty().type_id() {
+                if user_type != endpoint_type {
+                    return Err(EndpointError::DataTypeMismatch);
+                }
+            } else {
+                return Err(EndpointError::DataTypeMismatch);
+            }
+        }
+
+        let (reader, handler) = make_endpoint_connection(handle, endpoint.ty());
+
+        performer.outputs.push(handler);
+
+        Ok(Endpoint {
+            inner: OutputValue {
+                reader: Box::new(reader),
+                _marker: PhantomData,
+            },
+        })
+    }
+}
+
+macro_rules! primitive_impl {
+    ($handle:ident, $ty:ty, $atomic:ty) => {
+        let reader = Arc::new(<$atomic>::default());
+        let writer = Arc::clone(&reader);
+
+        return (
+            Box::new(move || Value::from(reader.load(Ordering::Relaxed))),
+            Box::new(move |performer: &mut PerformerPtr| {
+                let mut buffer = [0; std::mem::size_of::<$ty>()];
+                performer.copy_output_value($handle, &mut buffer);
+                writer.store(<$ty>::from_ne_bytes(buffer), Ordering::Relaxed);
+            }),
+        )
+    };
+}
+
+fn make_endpoint_connection(handle: EndpointHandle, ty: &Type) -> (Reader, EndpointHandler) {
+    match ty {
+        Type::Primitive(Primitive::Bool) => {
+            primitive_impl!(handle, i32, AtomicI32);
+        }
+        Type::Primitive(Primitive::Int32) => {
+            primitive_impl!(handle, i32, AtomicI32);
+        }
+        Type::Primitive(Primitive::Int64) => {
+            primitive_impl!(handle, i64, AtomicI64);
+        }
+        Type::Primitive(Primitive::Float32) => {
+            primitive_impl!(handle, f32, AtomicF32);
+        }
+        Type::Primitive(Primitive::Float64) => {
+            primitive_impl!(handle, f64, AtomicF64);
+        }
+        _ => {
+            let (mut reader, mut writer) = realtime_writer(None);
+
+            let ty = ty.to_owned();
+            let mut buffer = vec![0; ty.size()];
+            return (
+                Box::new(move || reader.get().unwrap_or(Value::Void)),
+                Box::new(move |performer| {
+                    performer.copy_output_value(handle, &mut buffer);
+                    writer.set(Some(
+                        ValueRef::new_from_slice(ty.as_ref(), &buffer).to_owned(),
+                    ));
+                }),
+            );
+        }
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,5 +1,5 @@
 //! Support for Cmajor values.
-
+pub(crate) mod reflect;
 pub mod types;
 mod values;
 

--- a/src/value/reflect.rs
+++ b/src/value/reflect.rs
@@ -1,0 +1,445 @@
+use {
+    crate::value::{
+        types::{Primitive, Type},
+        Value,
+    },
+    serde::{de::Visitor, Deserialize, Deserializer},
+    std::{any::TypeId, collections::VecDeque, fmt::Display},
+};
+
+pub(crate) trait Reflect: for<'de> Deserialize<'de> + 'static {
+    fn reflect() -> Result<Option<Type>, Error>;
+}
+
+impl<T> Reflect for T
+where
+    T: for<'de> Deserialize<'de> + 'static,
+{
+    fn reflect() -> Result<Option<Type>, Error> {
+        get_type::<T>()
+    }
+}
+
+fn get_type<T>() -> Result<Option<Type>, Error>
+where
+    T: Reflect,
+{
+    if TypeId::of::<T>() == TypeId::of::<Value>() {
+        return Ok(None);
+    }
+
+    let mut deserializer = TypeDeserializer {
+        ty: Type::Primitive(Primitive::Void),
+        fields: VecDeque::new(),
+    };
+    T::deserialize(&mut deserializer)?;
+    Ok(Some(deserializer.ty))
+}
+
+struct TypeDeserializer {
+    ty: Type,
+    fields: VecDeque<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("not supported")]
+    NotSupported,
+
+    #[error("unexpected field")]
+    UnexpectedField,
+
+    #[error("message: {0}")]
+    Serde(String),
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: Display>(msg: T) -> Self {
+        Error::Serde(msg.to_string())
+    }
+}
+
+impl<'a, 'de> Deserializer<'de> for &'a mut TypeDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match &mut self.ty {
+            Type::Object(object) => {
+                let field = self.fields.pop_front().ok_or(Error::UnexpectedField)?;
+                object.add_field(field, Primitive::Bool);
+            }
+            _ => {
+                self.ty = Type::Primitive(Primitive::Bool);
+            }
+        }
+
+        visitor.visit_bool(bool::default())
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match &mut self.ty {
+            Type::Object(object) => {
+                let field = self.fields.pop_front().ok_or(Error::UnexpectedField)?;
+                object.add_field(field, Primitive::Int32);
+            }
+            _ => {
+                self.ty = Type::Primitive(Primitive::Int32);
+            }
+        }
+
+        visitor.visit_i32(i32::default())
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match &mut self.ty {
+            Type::Object(object) => {
+                let field = self.fields.pop_front().ok_or(Error::UnexpectedField)?;
+                object.add_field(field, Primitive::Int64);
+            }
+            _ => {
+                self.ty = Type::Primitive(Primitive::Int64);
+            }
+        }
+
+        visitor.visit_i64(i64::default())
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match &mut self.ty {
+            Type::Object(object) => {
+                let field = self.fields.pop_front().ok_or(Error::UnexpectedField)?;
+                object.add_field(field, Primitive::Float32);
+            }
+            _ => {
+                self.ty = Type::Primitive(Primitive::Float32);
+            }
+        }
+
+        visitor.visit_f32(f32::default())
+    }
+
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match &mut self.ty {
+            Type::Object(object) => {
+                let field = self.fields.pop_front().ok_or(Error::UnexpectedField)?;
+                object.add_field(field, Primitive::Float64);
+            }
+            _ => {
+                self.ty = Type::Primitive(Primitive::Float64);
+            }
+        }
+
+        visitor.visit_f64(f64::default())
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut s = TypeDeserializer {
+            ty: Type::Object(Box::default()),
+            fields: fields.iter().map(|s| s.to_string()).collect(),
+        };
+        let result = visitor.visit_seq(SequenceAccess { de: &mut s })?;
+
+        match &mut self.ty {
+            Type::Object(ref mut object) => {
+                let field = self.fields.pop_front().ok_or(Error::UnexpectedField)?;
+                object.add_field(field, s.ty);
+            }
+            _ => {
+                self.ty = s.ty;
+            }
+        }
+
+        Ok(result)
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_identifier<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(Error::NotSupported)
+    }
+}
+
+struct SequenceAccess<'a> {
+    de: &'a mut TypeDeserializer,
+}
+
+impl<'a, 'de> serde::de::SeqAccess<'de> for SequenceAccess<'a> {
+    type Error = Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use {super::*, crate::value::Complex32, serde::Deserialize};
+
+    #[test]
+    fn primitive_types() {
+        assert_eq!(
+            get_type::<bool>().unwrap(),
+            Some(Type::Primitive(Primitive::Bool))
+        );
+        assert_eq!(
+            get_type::<i32>().unwrap(),
+            Some(Type::Primitive(Primitive::Int32))
+        );
+        assert_eq!(
+            get_type::<i64>().unwrap(),
+            Some(Type::Primitive(Primitive::Int64))
+        );
+        assert_eq!(
+            get_type::<f32>().unwrap(),
+            Some(Type::Primitive(Primitive::Float32))
+        );
+        assert_eq!(
+            get_type::<f64>().unwrap(),
+            Some(Type::Primitive(Primitive::Float64))
+        );
+    }
+
+    #[test]
+    fn structs() {
+        let ty = get_type::<Complex32>().unwrap().unwrap();
+        let object = ty.as_object().unwrap();
+
+        let fields = object.fields().collect::<Vec<_>>();
+        assert_eq!(fields.len(), 2);
+
+        assert_eq!(fields[0].name(), "imag");
+        assert_eq!(fields[0].ty(), &Type::Primitive(Primitive::Float32));
+        assert_eq!(fields[0].offset(), 0);
+
+        assert_eq!(fields[1].name(), "real");
+        assert_eq!(fields[1].ty(), &Type::Primitive(Primitive::Float32));
+        assert_eq!(fields[1].offset(), 4);
+    }
+
+    #[test]
+    fn nested_structs() {
+        #[derive(Deserialize)]
+        struct Outer {
+            _inner: Inner,
+        }
+
+        #[derive(Deserialize)]
+        struct Inner {
+            _a: bool,
+            _b: i32,
+        }
+
+        let ty = get_type::<Outer>().unwrap().unwrap();
+        let object = ty.as_object().unwrap();
+
+        let fields = object.fields().collect::<Vec<_>>();
+
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].name(), "_inner");
+
+        let inner = fields[0].ty().as_object().unwrap();
+        let inner_fields = inner.fields().collect::<Vec<_>>();
+
+        assert_eq!(inner_fields.len(), 2);
+        assert_eq!(inner_fields[0].name(), "_a");
+        assert_eq!(inner_fields[0].ty(), &Type::Primitive(Primitive::Bool));
+        assert_eq!(inner_fields[1].name(), "_b");
+        assert_eq!(inner_fields[1].ty(), &Type::Primitive(Primitive::Int32));
+    }
+}


### PR DESCRIPTION
Endpoints types can be checked once, and then we can avoid rechecking the type once the performer is running.